### PR TITLE
[RM-014] QueryDSL 검색 성능 개선

### DIFF
--- a/src/main/java/heukwu/recruitmentmanagement/post/controller/PostController.java
+++ b/src/main/java/heukwu/recruitmentmanagement/post/controller/PostController.java
@@ -4,6 +4,7 @@ import heukwu.recruitmentmanagement.post.service.Post;
 import heukwu.recruitmentmanagement.post.service.PostService;
 import heukwu.recruitmentmanagement.post.service.PostWithOtherPosts;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -11,13 +12,14 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class PostController {
 
     private final PostService postService;
 
     @GetMapping("/post")
-    public List<PostResponse.GetList> getAllPost(@RequestParam(required = false) PostSearch search, @RequestParam int page, @RequestParam int size) {
-        List<Post> postList = postService.getAllPost(search, page - 1, size);
+    public List<PostResponse.GetList> getAllPost(PostSearch search, @RequestParam int size, Long cursorId) {
+        List<Post> postList = postService.getAllPost(search, size, cursorId);
 
         return postList.stream()
                 .map(PostResponse.GetList::from)

--- a/src/main/java/heukwu/recruitmentmanagement/post/repository/PostRepository.java
+++ b/src/main/java/heukwu/recruitmentmanagement/post/repository/PostRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRepositoryCustom {
-
     List<PostEntity> findAllByCompanyId(long CompanyId);
 }

--- a/src/main/java/heukwu/recruitmentmanagement/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/heukwu/recruitmentmanagement/post/repository/PostRepositoryCustom.java
@@ -1,9 +1,9 @@
 package heukwu.recruitmentmanagement.post.repository;
 
 import heukwu.recruitmentmanagement.post.controller.PostSearch;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface PostRepositoryCustom {
-    Page<PostEntity> findBySearchOption(Pageable pageable, PostSearch search);
+    Slice<PostEntity> findBySearchOption(Long cursorId, PostSearch search, Pageable pageable);
 }

--- a/src/main/java/heukwu/recruitmentmanagement/post/service/PostService.java
+++ b/src/main/java/heukwu/recruitmentmanagement/post/service/PostService.java
@@ -9,8 +9,7 @@ import heukwu.recruitmentmanagement.post.repository.PostEntity;
 import heukwu.recruitmentmanagement.post.repository.PostEntityUpdatePolicy;
 import heukwu.recruitmentmanagement.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,10 +23,10 @@ public class PostService {
     private final PostRepository postRepository;
     private final CompanyRepository companyRepository;
 
-    public List<Post> getAllPost(PostSearch search, int page, int size) {
-        Page<PostEntity> postPage = postRepository.findBySearchOption(PageRequest.of(page, size), search);
+    public List<Post> getAllPost(PostSearch search, int size, Long cursorId) {
+        Slice<PostEntity> postEntities = postRepository.findBySearchOption(cursorId, search, PageRequest.ofSize(size));
 
-        return postPage.stream()
+        return postEntities.stream()
                 .map(i -> Post.from(i, companyRepository.findById(i.getCompanyId()).orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_COMPANY)).getCompanyName()))
                 .toList();
     }

--- a/src/test/java/heukwu/recruitmentmanagement/post/service/PostServiceTest.java
+++ b/src/test/java/heukwu/recruitmentmanagement/post/service/PostServiceTest.java
@@ -3,7 +3,6 @@ package heukwu.recruitmentmanagement.post.service;
 import heukwu.recruitmentmanagement.company.repository.Company;
 import heukwu.recruitmentmanagement.company.repository.CompanyRepository;
 import heukwu.recruitmentmanagement.exception.NotFoundException;
-import heukwu.recruitmentmanagement.post.controller.PostSearch;
 import heukwu.recruitmentmanagement.post.repository.PostEntity;
 import heukwu.recruitmentmanagement.post.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,8 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 import java.util.Optional;
@@ -69,17 +69,16 @@ public class PostServiceTest {
                 .description("Java Spring Back End")
                 .build();
 
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        PostSearch search = new PostSearch(null, null);
-
         List<PostEntity> postEntities = List.of(post.toEntity(naver.getId()), post.toEntity(kakao.getId()), post.toEntity(line.getId()));
         when(companyRepository.findById(1L)).thenReturn(Optional.ofNullable(naver));
         when(companyRepository.findById(2L)).thenReturn(Optional.ofNullable(kakao));
         when(companyRepository.findById(3L)).thenReturn(Optional.ofNullable(line));
-        when(postRepository.findBySearchOption(pageRequest, search)).thenReturn(new PageImpl<>(postEntities));
+
+        Slice<PostEntity> postEntitySlice = new SliceImpl<>(postEntities, PageRequest.ofSize(3), false);
+        when(postRepository.findBySearchOption(1L, null, PageRequest.ofSize(3))).thenReturn(postEntitySlice);
 
         //when
-        List<Post> allPost = postService.getAllPost(search, pageRequest.getPageNumber(), pageRequest.getPageSize());
+        List<Post> allPost = postService.getAllPost(null, 3, 1L);
 
         //then
         assertThat(allPost.size()).isEqualTo(3);


### PR DESCRIPTION
#14 

로컬 환경에 post 더미 데이터 100만개 입력하고 페이지당 10개씩 조회했을 때 n번째 페이지를 불러오는 시간 측정
|페이지|시간(ms)|
|--|--|
|1|15|
|100|25|
|100000|502|

1.  인덱스 적용 후 시간 측정

|페이지|시간(ms)|
|--|--|
|1|13|
|100|18|
|100000|182|

2. 커서 기반 페이징 적용 후 시간 측정

|페이지|시간(ms)|
|--|--|
|1|17|
|100|13|
|100000|16|

3. 인덱스 + 커서 기반 페이징 적용 후 시간 측정

|페이지|시간(ms)|
|--|--|
|1|11|
|100|15|
|100000|13|

최종 조회 시간 비교
||-|인덱스|커서 기반 페이징|인덱스 + 페이징|
|-|-|-|-|-|
|1페이지|15ms|13ms|17ms|11ms|
|100페이지|25ms|18ms|13ms|15ms|
|100000페이지|502ms|182ms|16ms|13ms|

블로그 정리
https://velog.io/@yyo4068/QueryDSL-검색-성능-개선